### PR TITLE
Make createAccordion() more defensive

### DIFF
--- a/action.php
+++ b/action.php
@@ -224,7 +224,8 @@ class action_plugin_tagadd extends DokuWiki_Action_Plugin
 	    $siteTags_cat = $this->categorysizeTags($siteTags);
 	    
 	    foreach($nsTags_cat as $category=>$tags) {
-	        $form->_content[]='<h3><a href="#">'.$category.' ('.count($siteTags_cat[$category]).'/'.count($tags).')</a></h3><div>';
+	        $catTagsCount = array_key_exists($category, $siteTags_cat) ? count($siteTags_cat[$category]) : '0';
+	        $form->_content[]='<h3><a href="#">'.$category.' ('.$catTagsCount.'/'.count($tags).')</a></h3><div>';
 	        foreach($tags as $tag){
 	            $chk_attrs=array();
 	            


### PR DESCRIPTION
I had a problem where, for some reason, `$siteTags_cat` was an empty array. This simple pull request adds a check if the array entry exists before passing it to `count()`.

This way, the plugin keeps working for the end user.  Otherwise the UI will hang.